### PR TITLE
add `headers` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare namespace got {
         followRedirect?: boolean;
 
         // Undocumented
+        headers?: any;
         rejectUnauthorized?: boolean;
         strictSSL?: boolean;
         ca?: any;


### PR DESCRIPTION
`headers` is a valid option but is not defined by the TypeScript definition file. Here is an example of using `headers`: https://github.com/sindresorhus/got#cookies

Not sure why it is lacking from the list of valid options @sindresorhus in the official `got` docs.
